### PR TITLE
Bugfixes and Improvements to odx Compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     license='MIT',
     description='A library for interfacing with UDS using python',
     classifiers=[
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.8",
         "Operating System :: OS Independent"
     ],
     include_package_data=True

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open("README.md", "r") as fh:
 setup(
     # Needed to silence warnings (and to be a worthwhile package)
     name='python-uds',
-    url='https://github.com/richClubb/python-uds',
+    url= 'https://github.com/1atabey1/python-uds',
     author='Richard Clubb',
     author_email='richard.clubb@embeduk.com',
     # Needed to actually package something
@@ -27,12 +27,10 @@ setup(
     # Needed for dependencies
     install_requires=['python-can>=3.0.0', 'python-lin>=0.1.0'],
     # *strongly* suggested for sharing
-    version='1.1.0',
+    version='1.1.1',
     # The license can be anything you like
     license='MIT',
     description='A library for interfacing with UDS using python',
-    # We will also need a readme eventually (there will be a warning)
-    # long_description=open('README.txt').read(),
     classifiers=[
         "Programming Language :: Python :: 3.6",
         "Operating System :: OS Independent"

--- a/uds/uds_communications/TransportProtocols/Can/CanConnection.py
+++ b/uds/uds_communications/TransportProtocols/Can/CanConnection.py
@@ -17,7 +17,7 @@ import can
 class CanConnection(object):
 
     def __init__(self, callback, filter, bus):
-        self.__bus = bus
+        self.__bus: can.interface.Bus = bus
         listener = can.Listener()
         listener.on_message_received = callback
         self.__notifier = can.Notifier(self.__bus, [listener], 0)
@@ -51,4 +51,9 @@ class CanConnection(object):
         canMsg.data = data
 
         self.__bus.send(canMsg)
+
+    def close(self):
+        self.__notifier.stop()
+        [listener.stop() for listener in self.__listeners]
+        self.__bus.shutdown()
 

--- a/uds/uds_communications/TransportProtocols/Can/CanConnectionFactory.py
+++ b/uds/uds_communications/TransportProtocols/Can/CanConnectionFactory.py
@@ -107,4 +107,5 @@ class CanConnectionFactory(object):
 
         if 'channel' in kwargs:
             CanConnectionFactory.config['vector']['channel'] = kwargs['channel']
+            CanConnectionFactory.config['socketcan']['channel'] = kwargs['channel']
 

--- a/uds/uds_communications/TransportProtocols/Can/CanConnectionFactory.py
+++ b/uds/uds_communications/TransportProtocols/Can/CanConnectionFactory.py
@@ -5,14 +5,14 @@ from os import path
 from platform import system
 #from uds import CanConnection
 from uds.uds_communications.TransportProtocols.Can.CanConnection import CanConnection
-
+from typing import Dict
 # used to conditionally import socketcan for linux to avoid error messages
 if system() == "Linux":
     from can.interfaces import socketcan
 
 class CanConnectionFactory(object):
 
-    connections = {}
+    connections: Dict[str, CanConnection] = {}
     config = None
 
     @staticmethod

--- a/uds/uds_communications/TransportProtocols/Can/CanTp.py
+++ b/uds/uds_communications/TransportProtocols/Can/CanTp.py
@@ -67,7 +67,7 @@ class CanTp(iTp):
             self.__addressingType = CanTpAddressingTypes.NORMAL
         elif addressingType == "NORMAL_FIXED":
             self.__addressingType = CanTpAddressingTypes.NORMAL_FIXED
-        elif self.__addressingType == "EXTENDED":
+        elif addressingType == "EXTENDED":
             self.__addressingType = CanTpAddressingTypes.EXTENDED
         elif addressingType == "MIXED":
             self.__addressingType = CanTpAddressingTypes.MIXED
@@ -452,15 +452,16 @@ class CanTp(iTp):
 
         transmitData = [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
 
-        if (
-            (self.__addressingType == CanTpAddressingTypes.NORMAL) |
-            (self.__addressingType == CanTpAddressingTypes.NORMAL_FIXED)
-        ):
+        if self.__addressingType == CanTpAddressingTypes.NORMAL or \
+                self.__addressingType == CanTpAddressingTypes.NORMAL_FIXED:
             transmitData = data
+            self.__connection.transmit(transmitData, self.__reqId)
         elif self.__addressingType == CanTpAddressingTypes.MIXED:
             transmitData[0] = self.__N_AE
             transmitData[1:] = data
+            self.__connection.transmit(transmitData, self.__reqId)
+        elif self.__addressingType == CanTpAddressingTypes.EXTENDED:
+            transmitData = data
+            self.__connection.transmit(transmitData, self.__reqId)
         else:
             raise Exception("I do not know how to send this addressing type")
-
-        self.__connection.transmit(transmitData, self.__reqId, )

--- a/uds/uds_communications/TransportProtocols/Can/CanTp.py
+++ b/uds/uds_communications/TransportProtocols/Can/CanTp.py
@@ -104,14 +104,9 @@ class CanTp(iTp):
     ##
     # @brief used to load the local configuration options and override them with any passed in from a config file
     def __loadConfiguration(self, configPath, **kwargs):
-
         #load the base config
         baseConfig = path.dirname(__file__) + "/config.ini"
         self.__config = Config()
-        if path.exists(baseConfig):
-            self.__config.read(baseConfig)
-        else:
-            raise FileNotFoundError("No base config file")
 
         # check the config path
         if configPath is not None:
@@ -119,6 +114,11 @@ class CanTp(iTp):
                 self.__config.read(configPath)
             else:
                 raise FileNotFoundError("specified config not found")
+        else:
+            if path.exists(baseConfig):
+                self.__config.read(baseConfig)
+            else:
+                raise FileNotFoundError("No base config file")
 
     ##
     # @brief goes through the kwargs and overrides any of the local configuration options

--- a/uds/uds_communications/TransportProtocols/Can/CanTp.py
+++ b/uds/uds_communications/TransportProtocols/Can/CanTp.py
@@ -461,7 +461,8 @@ class CanTp(iTp):
             transmitData[1:] = data
             self.__connection.transmit(transmitData, self.__reqId)
         elif self.__addressingType == CanTpAddressingTypes.EXTENDED:
-            transmitData = data
-            self.__connection.transmit(transmitData, self.__reqId)
+            transmitData[0] = self.__N_AE
+            transmitData[1:] = data
+            self.__connection.transmit(transmitData, self.__reqId, extended=True)
         else:
             raise Exception("I do not know how to send this addressing type")

--- a/uds/uds_communications/TransportProtocols/Can/CanTp.py
+++ b/uds/uds_communications/TransportProtocols/Can/CanTp.py
@@ -352,7 +352,8 @@ class CanTp(iTp):
     def closeConnection(self):
         # deregister filters, listeners and notifiers etc
         # close can connection
-        pass
+        for _, conn in CanConnectionFactory.connections.items():
+            conn.close()
 
     ##
     # @brief clear out the receive list

--- a/uds/uds_communications/TransportProtocols/Lin/LinTp.py
+++ b/uds/uds_communications/TransportProtocols/Lin/LinTp.py
@@ -243,7 +243,7 @@ class LinTp(iTp):
                 counter = 0
                 currBlock = []
 
-        if len(currBlock) is not 0:
+        if len(currBlock) != 0:
             blockList.append(fillArray(currBlock, self.__maxPduLength))
 
         return blockList

--- a/uds/uds_communications/TransportProtocols/Lin/LinTp.py
+++ b/uds/uds_communications/TransportProtocols/Lin/LinTp.py
@@ -279,10 +279,6 @@ class LinTp(iTp):
         # load the base config
         baseConfig = path.dirname(__file__) + "/config.ini"
         self.__config = Config()
-        if path.exists(baseConfig):
-            self.__config.read(baseConfig)
-        else:
-            raise FileNotFoundError("No base config file")
 
         # check the config path
         if configPath is not None:
@@ -290,6 +286,11 @@ class LinTp(iTp):
                 self.__config.read(configPath)
             else:
                 raise FileNotFoundError("specified config not found")
+        else:
+            if path.exists(baseConfig):
+                self.__config.read(baseConfig)
+            else:
+                raise FileNotFoundError("No base config file")
 
     ##
     # @brief goes through the kwargs and overrides any of the local configuration options

--- a/uds/uds_communications/TransportProtocols/TpFactory.py
+++ b/uds/uds_communications/TransportProtocols/TpFactory.py
@@ -54,10 +54,6 @@ class TpFactory(object):
         #load the base config
         baseConfig = path.dirname(__file__) + "/config.ini"
         config = Config()
-        if path.exists(baseConfig):
-            config.read(baseConfig)
-        else:
-            raise FileNotFoundError("No base config file")
 
         # check the config path
         if configPath is not None:
@@ -65,6 +61,11 @@ class TpFactory(object):
                 config.read(configPath)
             else:
                 raise FileNotFoundError("specified config not found")
+        else:
+            if path.exists(baseConfig):
+                config.read(baseConfig)
+            else:
+                raise FileNotFoundError("No base config file")
 
         TpFactory.config = config
 

--- a/uds/uds_communications/Uds/Uds.py
+++ b/uds/uds_communications/Uds/Uds.py
@@ -44,24 +44,14 @@ class Uds(object):
 
         # used as a semaphore for the tester present
         self.__transmissionActive_flag = False
-        #print(("__transmissionActive_flag initialised (clear):",self.__transmissionActive_flag))
-        # The above flag should prevent testerPresent operation, but in case of race conditions, this lock prevents actual overlapo in the sending
         self.sendLock = threading.Lock()
 
         # Process any ihex file that has been associated with the ecu at initialisation
         self.__ihexFile = ihexFileParser(ihexFile) if ihexFile is not None else None
 
-
-
     def __loadConfiguration(self, configPath=None):
-
         baseConfig = path.dirname(__file__) + "/config.ini"
-        # print(baseConfig)
         self.__config = Config()
-        if path.exists(baseConfig):
-            self.__config.read(baseConfig)
-        else:
-            raise FileNotFoundError("No base config file")
 
         # check the config path
         if configPath is not None:
@@ -69,6 +59,11 @@ class Uds(object):
                 self.__config.read(configPath)
             else:
                 raise FileNotFoundError("specified config not found")
+        else:
+            if path.exists(baseConfig):
+                self.__config.read(baseConfig)
+            else:
+                raise FileNotFoundError("No base config file")
 
     def __checkKwargs(self, **kwargs):
 

--- a/uds/uds_config_tool/DecodeFunctions.py
+++ b/uds/uds_config_tool/DecodeFunctions.py
@@ -51,6 +51,8 @@ def intArrayToUInt8Array(aArray, inputType):
 
 
 def intArrayToIntArray(aArray, inputType, outputType):
+    if type(aArray) != list:
+        aArray = [aArray]
     if (inputType == 'uint32'):
         inputFunc = lambda x: [extractIntFromPosition(x, 8, 24), extractIntFromPosition(x, 8, 16),
                           extractIntFromPosition(x, 8, 8), extractIntFromPosition(x, 8, 0)]

--- a/uds/uds_config_tool/FunctionCreation/ReadDataByIdentifierMethodFactory.py
+++ b/uds/uds_config_tool/FunctionCreation/ReadDataByIdentifierMethodFactory.py
@@ -199,7 +199,14 @@ class ReadDataByIdentifierMethodFactory(IServiceMethodFactory):
                     dataObjectElement = xmlElements[(param.find('DOP-REF')).attrib['ID-REF']]
                     longName = param.find('LONG-NAME').text
                     bytePosition = int(param.find('BYTE-POSITION').text)
-                    bitLength = int(dataObjectElement.find('DIAG-CODED-TYPE').find('BIT-LENGTH').text)
+                    # catch exceptions when querying for bit length
+                    try:
+                        bitLength = int(dataObjectElement.find('DIAG-CODED-TYPE').find('BIT-LENGTH').text)
+                    except:    # dataObjectElement might be pointing to higher level structure
+                        dataObjectElement = \
+                            xmlElements[(dataObjectElement.find('PARAMS')).find('PARAM').find('DOP-REF').attrib['ID-REF']]
+                        bitLength = int(dataObjectElement.find('DIAG-CODED-TYPE').find('BIT-LENGTH').text)
+
                     listLength = int(bitLength / 8)
                     endPosition = bytePosition + listLength
                     encodingType = dataObjectElement.find('DIAG-CODED-TYPE').attrib['BASE-DATA-TYPE']

--- a/uds/uds_config_tool/FunctionCreation/RoutineControlMethodFactory.py
+++ b/uds/uds_config_tool/FunctionCreation/RoutineControlMethodFactory.py
@@ -181,12 +181,12 @@ Also, we will most need to handle scaling at some stage within DecodeFunctions.p
 
                     # 
                     encodeFunctions.append("encoded += {}".format(functionStringList))
-                    encodeFunction = "    else:\n" \
-                                     "      if type(optionRecord) == list:\n" \
-                                     "          for elem in dataRecord:\n" \
-                                     "              encoded += {0}\n" \
-                                     "      else:\n" \
-                                     "          encoded = {1}".format(
+                    encodeFunction = "        else:\n" \
+                                     "          if type(optionRecord) == list:\n" \
+                                     "              for elem in optionRecord:\n" \
+                                     "                  encoded += {0}\n" \
+                                     "          else:\n" \
+                                     "              encoded = {1}".format(
                         functionStringSingle.replace("optionRecord", "elem"),
                         functionStringSingle)
 

--- a/uds/uds_config_tool/FunctionCreation/RoutineControlMethodFactory.py
+++ b/uds/uds_config_tool/FunctionCreation/RoutineControlMethodFactory.py
@@ -9,7 +9,6 @@ __maintainer__ = "Richard Clubb"
 __email__ = "richard.clubb@embeduk.com"
 __status__ = "Development"
 
-
 from uds.uds_config_tool import DecodeFunctions
 import sys
 from uds.uds_config_tool.FunctionCreation.iServiceMethodFactory import IServiceMethodFactory
@@ -26,7 +25,7 @@ requestFuncTemplate = str("def {0}(optionRecord,suppressResponse=False):\n"
                           "            drDict = dict(optionRecord)\n"
                           "            {4}\n"
                           "{5}\n"
-                          "    return {1} + controlType + {3} + encoded")						  
+                          "    return {1} + controlType + {3} + encoded")
 
 # Note: we do not need to cater for response suppression checking as nothing to check if response is suppressed - always unsuppressed
 checkFunctionTemplate = str("def {0}(input):\n"
@@ -61,7 +60,7 @@ class RoutineControlMethodFactory(IServiceMethodFactory):
         # Avoiding the overwrite by ignoring the send-only versions, i.e. these are identical other than positive response details being missing.
         try:
             if diagServiceElement.attrib['TRANSMISSION-MODE'] == 'SEND-ONLY':
-                return (None,"")
+                return (None, "")
         except:
             pass
 
@@ -84,15 +83,16 @@ class RoutineControlMethodFactory(IServiceMethodFactory):
                 except AttributeError:
                     pass
 
-                if(semantic == 'SERVICE-ID'):
+                if (semantic == 'SERVICE-ID'):
                     serviceId = [int(param.find('CODED-VALUE').text)]
-                elif(semantic == 'SUBFUNCTION'):
+                elif (semantic == 'SUBFUNCTION'):
                     controlType = [int(param.find('CODED-VALUE').text)]
                     if controlType[0] >= SUPPRESS_RESPONSE_BIT:
                         pass
-                        #raise ValueError("ECU Reset:reset type exceeds maximum value (received {0})".format(resetType[0]))
-                elif(semantic == 'ID'):
-                    routineId = DecodeFunctions.intArrayToIntArray([int(param.find('CODED-VALUE').text)], 'int16', 'int8')
+                        # raise ValueError("ECU Reset:reset type exceeds maximum value (received {0})".format(resetType[0]))
+                elif (semantic == 'ID'):
+                    routineId = DecodeFunctions.intArrayToIntArray([int(param.find('CODED-VALUE').text)], 'int16',
+                                                                   'int8')
                 elif semantic == 'DATA':
                     dataObjectElement = xmlElements[(param.find('DOP-REF')).attrib['ID-REF']]
                     longName = param.find('LONG-NAME').text
@@ -101,28 +101,65 @@ class RoutineControlMethodFactory(IServiceMethodFactory):
                     try:
                         encodingType = dataObjectElement.find('DIAG-CODED-TYPE').attrib['BASE-DATA-TYPE']
                     except:
-                        encodingType = "unknown"  # ... for now just drop into the "else" catch-all ??????????????????????????????????????????????
-                    if(encodingType) == "A_ASCIISTRING":
+                        encodingType = "unknown"  # ... for now just drop into the "else" catch-all ???????!!!!!!!
+
+                    # We need to always respect given bit lengths!
+                    try:
+                        bitLength = int(dataObjectElement.find('DIAG-CODED-TYPE').find('BIT-LENGTH').text)
+                    except:
+                        bitLength = 32  # just assume maximum length when in doubt
+
+                    if (encodingType) == "A_ASCIISTRING":
                         functionStringList = "DecodeFunctions.stringToIntList(drDict['{0}'], None)".format(longName)
                         functionStringSingle = "DecodeFunctions.stringToIntList(optionRecord, None)"
-                    elif(encodingType) == "A_INT8":
-                        functionStringList = "DecodeFunctions.intArrayToIntArray(drDict['{0}'], 'int8', 'int8')".format(longName)
+                    elif (encodingType) == "A_INT8":
+                        functionStringList = "DecodeFunctions.intArrayToIntArray(drDict['{0}'], 'int8', 'int8')".format(
+                            longName)
                         functionStringSingle = "DecodeFunctions.intArrayToIntArray(optionRecord, 'int8', 'int8')"
-                    elif(encodingType) == "A_INT16":
-                        functionStringList = "DecodeFunctions.intArrayToIntArray(drDict['{0}'], 'int16', 'int8')".format(longName)
+                    elif (encodingType) == "A_INT16":
+                        functionStringList = "DecodeFunctions.intArrayToIntArray(drDict['{0}'], 'int16', 'int8')".format(
+                            longName)
                         functionStringSingle = "DecodeFunctions.intArrayToIntArray(optionRecord, 'int16', 'int8')"
-                    elif(encodingType) == "A_INT32":
-                        functionStringList = "DecodeFunctions.intArrayToIntArray(drDict['{0}'], 'int32', 'int8')".format(longName)
+                        if bitLength < 16:
+                            functionStringList = functionStringList + "[1:]"
+                            functionStringSingle = functionStringSingle + "[1:]"
+                    elif (encodingType) == "A_INT32":
+                        functionStringList = "DecodeFunctions.intArrayToIntArray(drDict['{0}'], 'int32', 'int8')".format(
+                            longName)
                         functionStringSingle = "DecodeFunctions.intArrayToIntArray(optionRecord, 'int32', 'int8')"
-                    elif(encodingType) == "A_UINT8":
-                        functionStringList = "DecodeFunctions.intArrayToIntArray(drDict['{0}'], 'uint8', 'int8')".format(longName)
+                        if bitLength == 8:
+                            functionStringList = functionStringList + "[3:]"
+                            functionStringSingle = functionStringSingle + "[3:]"
+                        elif bitLength == 16:
+                            functionStringList = functionStringList + "[2:]"
+                            functionStringSingle = functionStringSingle + "[2:]"
+                        elif bitLength == 24:
+                            functionStringList = functionStringList + "[1:]"
+                            functionStringSingle = functionStringSingle + "[1:]"
+                    elif (encodingType) == "A_UINT8":
+                        functionStringList = "DecodeFunctions.intArrayToIntArray(drDict['{0}'], 'uint8', 'int8')".format(
+                            longName)
                         functionStringSingle = "DecodeFunctions.intArrayToIntArray(optionRecord, 'uint8', 'int8')"
-                    elif(encodingType) == "A_UINT16":
-                        functionStringList = "DecodeFunctions.intArrayToIntArray(drDict['{0}'], 'uint16', 'int8')".format(longName)
+                    elif (encodingType) == "A_UINT16":
+                        functionStringList = "DecodeFunctions.intArrayToIntArray(drDict['{0}'], 'uint16', 'int8')".format(
+                            longName)
                         functionStringSingle = "DecodeFunctions.intArrayToIntArray(optionRecord, 'uint16', 'int8')"
-                    elif(encodingType) == "A_UINT32":
-                        functionStringList = "DecodeFunctions.intArrayToIntArray(drDict['{0}'], 'uint32', 'int8')".format(longName)
+                        if bitLength < 16:
+                            functionStringList = functionStringList + "[1:]"
+                            functionStringSingle = functionStringSingle + "[1:]"
+                    elif (encodingType) == "A_UINT32":
+                        functionStringList = "DecodeFunctions.intArrayToIntArray(drDict['{0}'], 'uint32', 'int8')".format(
+                            longName)
                         functionStringSingle = "DecodeFunctions.intArrayToIntArray(optionRecord, 'uint32', 'int8')"
+                        if bitLength == 8:
+                            functionStringList = functionStringList + "[3:]"
+                            functionStringSingle = functionStringSingle + "[3:]"
+                        elif bitLength == 16:
+                            functionStringList = functionStringList + "[2:]"
+                            functionStringSingle = functionStringSingle + "[2:]"
+                        elif bitLength == 24:
+                            functionStringList = functionStringList + "[1:]"
+                            functionStringSingle = functionStringSingle + "[1:]"
                     else:
                         functionStringList = "drDict['{0}']".format(longName)
                         functionStringSingle = "optionRecord"
@@ -143,24 +180,31 @@ Also, we will most need to handle scaling at some stage within DecodeFunctions.p
                     """
 
                     # 
-                    encodeFunctions.append("encoded += {1}".format(longName,functionStringList))
-                    encodeFunction = "        else:\n            encoded = {1}".format(longName,functionStringSingle)
+                    encodeFunctions.append("encoded += {}".format(functionStringList))
+                    encodeFunction = "    else:\n" \
+                                     "      if type(optionRecord) == list:\n" \
+                                     "          for elem in dataRecord:\n" \
+                                     "              encoded += {0}\n" \
+                                     "      else:\n" \
+                                     "          encoded = {1}".format(
+                        functionStringSingle.replace("optionRecord", "elem"),
+                        functionStringSingle)
 
 
             except:
                 pass
 
-        funcString = requestFuncTemplate.format(shortName, # 0
-                                                serviceId, # 1
-                                                controlType, # 2
-                                                routineId, # 3
-												"\n            ".join(encodeFunctions),  # ... handles input via list # 4
-												encodeFunction,                      # ... handles input via single value # 5
-                                                SUPPRESS_RESPONSE_BIT) # 6
+        funcString = requestFuncTemplate.format(shortName,  # 0
+                                                serviceId,  # 1
+                                                controlType,  # 2
+                                                routineId,  # 3
+                                                "\n            ".join(encodeFunctions),
+                                                # ... handles input via list # 4
+                                                encodeFunction,  # ... handles input via single value # 5
+                                                SUPPRESS_RESPONSE_BIT)  # 6
         exec(funcString)
-        return (locals()[shortName],str(controlType))
-		
-		
+        return (locals()[shortName], str(controlType))
+
     ##
     # @brief method to create the function to check the positive response for validity
     @staticmethod
@@ -186,7 +230,8 @@ Also, we will most need to handle scaling at some stage within DecodeFunctions.p
 
         shortName = diagServiceElement.find('SHORT-NAME').text
         checkFunctionName = "check_{0}".format(shortName)
-        positiveResponseElement = xmlElements[(diagServiceElement.find('POS-RESPONSE-REFS')).find('POS-RESPONSE-REF').attrib['ID-REF']]
+        positiveResponseElement = xmlElements[
+            (diagServiceElement.find('POS-RESPONSE-REFS')).find('POS-RESPONSE-REF').attrib['ID-REF']]
 
         paramsElement = positiveResponseElement.find('PARAMS')
 
@@ -203,57 +248,55 @@ Also, we will most need to handle scaling at some stage within DecodeFunctions.p
 
                 startByte = int(param.find('BYTE-POSITION').text)
 
-                if(semantic == 'SERVICE-ID'):
+                if (semantic == 'SERVICE-ID'):
                     responseId = int(param.find('CODED-VALUE').text)
                     bitLength = int((param.find('DIAG-CODED-TYPE')).find('BIT-LENGTH').text)
                     listLength = int(bitLength / 8)
                     responseIdStart = startByte
                     responseIdEnd = startByte + listLength
                     totalLength += listLength
-                elif(semantic == 'SUBFUNCTION'):
+                elif (semantic == 'SUBFUNCTION'):
                     controlType = int(param.find('CODED-VALUE').text)
                     bitLength = int((param.find('DIAG-CODED-TYPE')).find('BIT-LENGTH').text)
                     listLength = int(bitLength / 8)
                     controlTypeStart = startByte
                     controlTypeEnd = startByte + listLength
                     totalLength += listLength
-                elif(semantic == 'ID'):
+                elif (semantic == 'ID'):
                     routineId = int(param.find('CODED-VALUE').text)
                     bitLength = int((param.find('DIAG-CODED-TYPE')).find('BIT-LENGTH').text)
                     listLength = int(bitLength / 8)
                     routineIdStart = startByte
                     routineIdEnd = startByte + listLength
                     totalLength += listLength
-                elif(semantic == 'DATA'):
+                elif (semantic == 'DATA'):
                     dataObjectElement = xmlElements[(param.find('DOP-REF')).attrib['ID-REF']]
-                    if(dataObjectElement.tag == "DATA-OBJECT-PROP"):
+                    if (dataObjectElement.tag == "DATA-OBJECT-PROP"):
                         start = int(param.find('BYTE-POSITION').text)
                         bitLength = int(dataObjectElement.find('DIAG-CODED-TYPE').find('BIT-LENGTH').text)
-                        listLength = int(bitLength/8)
+                        listLength = int(bitLength / 8)
                         totalLength += listLength
                     else:
                         pass
                 else:
                     pass
             except:
-                #print(sys.exc_info())
+                # print(sys.exc_info())
                 pass
 
-
-        checkFunctionString = checkFunctionTemplate.format(checkFunctionName, # 0
-                                                           responseId, # 1
-                                                           controlType, # 2
-                                                           routineId, # 3
-                                                           responseIdStart, # 4
-                                                           responseIdEnd, # 5
-                                                           controlTypeStart, # 6
-                                                           controlTypeEnd, # 7
-                                                           routineIdStart, # 8
-                                                           routineIdEnd, # 9
-                                                           totalLength) # 10
+        checkFunctionString = checkFunctionTemplate.format(checkFunctionName,  # 0
+                                                           responseId,  # 1
+                                                           controlType,  # 2
+                                                           routineId,  # 3
+                                                           responseIdStart,  # 4
+                                                           responseIdEnd,  # 5
+                                                           controlTypeStart,  # 6
+                                                           controlTypeEnd,  # 7
+                                                           routineIdStart,  # 8
+                                                           routineIdEnd,  # 9
+                                                           totalLength)  # 10
         exec(checkFunctionString)
         return locals()[checkFunctionName]
-
 
     ##
     # @brief method to encode the positive response from the raw type to it physical representation
@@ -270,8 +313,9 @@ Also, we will most need to handle scaling at some stage within DecodeFunctions.p
         # The values in the response are SID, resetType, and optionally the powerDownTime (only for resetType 0x04). Checking is handled in the check function, 
         # so must be present and ok. This function is only required to return the resetType and powerDownTime (if present).
 
-        positiveResponseElement = xmlElements[(diagServiceElement.find('POS-RESPONSE-REFS')).find('POS-RESPONSE-REF').attrib['ID-REF']]
-		
+        positiveResponseElement = xmlElements[
+            (diagServiceElement.find('POS-RESPONSE-REFS')).find('POS-RESPONSE-REF').attrib['ID-REF']]
+
         shortName = diagServiceElement.find('SHORT-NAME').text
         encodePositiveResponseFunctionName = "encode_{0}".format(shortName)
 
@@ -294,7 +338,7 @@ Also, we will most need to handle scaling at some stage within DecodeFunctions.p
                     listLength = int(bitLength / 8)
                     endPosition = bytePosition + listLength
                     encodingType = param.find('DIAG-CODED-TYPE').attrib['BASE-DATA-TYPE']
-                    if(encodingType) == "A_ASCIISTRING":
+                    if (encodingType) == "A_ASCIISTRING":
                         functionString = "DecodeFunctions.intListToString(input[{0}:{1}], None)".format(bytePosition,
                                                                                                         endPosition)
                     else:
@@ -310,7 +354,7 @@ Also, we will most need to handle scaling at some stage within DecodeFunctions.p
                     listLength = int(bitLength / 8)
                     endPosition = bytePosition + listLength
                     encodingType = param.find('DIAG-CODED-TYPE').attrib['BASE-DATA-TYPE']
-                    if(encodingType) == "A_ASCIISTRING":
+                    if (encodingType) == "A_ASCIISTRING":
                         functionString = "DecodeFunctions.intListToString(input[{0}:{1}], None)".format(bytePosition,
                                                                                                         endPosition)
                     else:
@@ -327,10 +371,10 @@ Also, we will most need to handle scaling at some stage within DecodeFunctions.p
                     listLength = int(bitLength / 8)
                     endPosition = bytePosition + listLength
                     encodingType = dataObjectElement.find('DIAG-CODED-TYPE').attrib['BASE-DATA-TYPE']
-                    if(encodingType) == "A_ASCIISTRING":
+                    if (encodingType) == "A_ASCIISTRING":
                         functionString = "DecodeFunctions.intListToString(input[{0}:{1}], None)".format(bytePosition,
                                                                                                         endPosition)
-                    elif(encodingType == "A_UINT32"):
+                    elif (encodingType == "A_UINT32"):
                         functionString = "input[{1}:{2}]".format(longName,
                                                                  bytePosition,
                                                                  endPosition)
@@ -347,8 +391,6 @@ Also, we will most need to handle scaling at some stage within DecodeFunctions.p
                                                                          "\n    ".join(encodeFunctions))
         exec(encodeFunctionString)
         return locals()[encodePositiveResponseFunctionName]
-
-
 
     ##
     # @brief method to create the negative response function for the service element
@@ -387,12 +429,13 @@ Also, we will most need to handle scaling at some stage within DecodeFunctions.p
                     start = int(param.find('BYTE-POSITION').text)
                     diagCodedType = param.find('DIAG-CODED-TYPE')
                     bitLength = int((param.find('DIAG-CODED-TYPE')).find('BIT-LENGTH').text)
-                    listLength = int(bitLength/8)
+                    listLength = int(bitLength / 8)
                     end = start + listLength
 
-                    checkString = "if input[{0}:{1}] == [{2}]: raise Exception(\"Detected negative response: {{0}}\".format(str([hex(n) for n in input])))".format(start,
-                                                                                                                                                                   end,
-                                                                                                                                                                   serviceId)
+                    checkString = "if input[{0}:{1}] == [{2}]: raise Exception(\"Detected negative response: {{0}}\".format(str([hex(n) for n in input])))".format(
+                        start,
+                        end,
+                        serviceId)
                     negativeResponseChecks.append(checkString)
 
                     pass


### PR DESCRIPTION
Functionally this pull request should not change anything, however, I did run into some issues when using an odx file that was exported from a recent version of CANdelaStudio:

- 8 bit long parameters can sometimes have base type uint32 which lead to mixed up byte positions and incorrect lengths in the final PDU. Fixed this by also taking the bit lengths into account while creating request functions (when relevant)
- Some typos in the extended id handling prevented extended ids to be processed properly
- some minor stuff and formatting (didnt wanna produce a huge diff so only reformatted one file where it bothered me the most :) )