### PR TITLE
default baudrate couldn't be changed for pcan

### DIFF
--- a/uds/uds_communications/TransportProtocols/Can/CanConnectionFactory.py
+++ b/uds/uds_communications/TransportProtocols/Can/CanConnectionFactory.py
@@ -38,7 +38,7 @@ class CanConnectionFactory(object):
         elif connectionType == 'peak':
             channel = CanConnectionFactory.config['peak']['device']
             if channel not in CanConnectionFactory.connections:
-                baudrate = CanConnectionFactory.config['can']['baudrate']
+                baudrate = int( CanConnectionFactory.config['can']['baudrate'] )
                 CanConnectionFactory.connections[channel] = CanConnection(callback, filter,
                                                                           pcan.PcanBus(channel,
                                                                           bitrate=baudrate))


### PR DESCRIPTION
The overall CanConnection parameter handling forces each parameter to be a string value, but the pcan bus driver expected the baudrate (=bitrate) to be an integer value