### PR TITLE
remove hard coded path seperator

### DIFF
--- a/uds/uds_communications/TransportProtocols/Can/CanConnectionFactory.py
+++ b/uds/uds_communications/TransportProtocols/Can/CanConnectionFactory.py
@@ -81,7 +81,7 @@ class CanConnectionFactory(object):
 
         CanConnectionFactory.config = Config()
 
-        localConfig = path.dirname(__file__) + "/config.ini"
+        localConfig = path.join(path.dirname(__file__), "config.ini")
         CanConnectionFactory.config.read(localConfig)
 
         if configPath is not None:

--- a/uds/uds_communications/TransportProtocols/Can/CanTp.py
+++ b/uds/uds_communications/TransportProtocols/Can/CanTp.py
@@ -106,7 +106,7 @@ class CanTp(iTp):
     def __loadConfiguration(self, configPath, **kwargs):
 
         #load the base config
-        baseConfig = path.dirname(__file__) + "/config.ini"
+        baseConfig = path.join(path.dirname(__file__), "config.ini")
         self.__config = Config()
         if path.exists(baseConfig):
             self.__config.read(baseConfig)

--- a/uds/uds_communications/TransportProtocols/Lin/LinTp.py
+++ b/uds/uds_communications/TransportProtocols/Lin/LinTp.py
@@ -277,7 +277,7 @@ class LinTp(iTp):
     # @brief used to load the local configuration options and override them with any passed in from a config file
     def __loadConfiguration(self, configPath, **kwargs):
         # load the base config
-        baseConfig = path.dirname(__file__) + "/config.ini"
+        baseConfig = path.join(path.dirname(__file__), "config.ini")
         self.__config = Config()
         if path.exists(baseConfig):
             self.__config.read(baseConfig)

--- a/uds/uds_communications/Uds/Uds.py
+++ b/uds/uds_communications/Uds/Uds.py
@@ -55,7 +55,7 @@ class Uds(object):
 
     def __loadConfiguration(self, configPath=None):
 
-        baseConfig = path.dirname(__file__) + "/config.ini"
+        baseConfig = path.join(path.dirname(__file__), "config.ini")
         # print(baseConfig)
         self.__config = Config()
         if path.exists(baseConfig):


### PR DESCRIPTION
I had made small changes for MacOS. The Windows path separator didn't work on MacOS. 
Please check my changes and feel free to make any suggestions.

Thanks a lot.